### PR TITLE
修复两个 bug：重试误判 + 任务饥饿

### DIFF
--- a/TranslatorTask.cs
+++ b/TranslatorTask.cs
@@ -207,7 +207,7 @@ public class TranslatorTask
                     }
                     if (task.retryCount > 2 && tasks.Count > 0)
                     {
-                        continue;
+                        break;
                     }
                     toltoken += taskToken;
                     tasks.Add(task);
@@ -497,7 +497,7 @@ public class TranslatorTask
             foreach (var task in tasks)
             {
                 //失败了重新翻译
-                if (task.state != TaskData.TaskState.Completed)
+                if (task.state != TaskData.TaskState.Completed && task.state != TaskData.TaskState.Closed)
                 {
                     task.retryCount++;
                     if (task.retryCount < _maxRetry)


### PR DESCRIPTION
## 修复一：TryRespond 成功后 Closed 被误判重试

**根因**：`TryRespond()` 发送 HTTP 响应后将 `task.state` 从 `Completed` 改为 `Closed`，并从 `taskDatas` 中移除该任务。`finally` 块的重试判断仅跳过 `Completed`，导致 `Closed` 被误判为失败而进入重试分支。

**影响**：成功任务在 `finally` 中被错误重置 `state=Waiting`、清空 `result`、`retryCount` 误增。因任务此时已从 `taskDatas` 移除，不会重新入队翻译，但其内部状态被污染（`retryCount` 累积错误、`result` 被清空）。

**修复**（1 行）：
```diff
- if (task.state != TaskData.TaskState.Completed)
+ if (task.state != TaskData.TaskState.Completed && task.state != TaskData.TaskState.Closed)
```

---

## 修复二：SelectTasks retryCount>2 任务被混批

**根因**：`retryCount>2` 的文本被设计为不与其他任务混批（隔离处理），但实现用 `continue` 跳过当前任务后继续收集后续任务，导致该高重试任务被跳过、而其后的任务被混入同一批次，破坏了隔离语义。

**修复**（1 行）：
```diff
  if (task.retryCount > 2 && tasks.Count > 0)
  {
-     continue;
+     break;
  }
```

改为 `break` 终止当前批次收集，使该高重试任务在下轮 `SelectTasks` 中作为首位被单独选中处理，保持原有的隔离语义。

---

两个修复均来自实际使用中发现并验证，改动各一行，零副作用。